### PR TITLE
ci: add cask validation workflow

### DIFF
--- a/.github/workflows/validate-cask.yml
+++ b/.github/workflows/validate-cask.yml
@@ -1,0 +1,63 @@
+name: Validate Homebrew cask
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - Casks/hackdesk.rb
+      - .github/workflows/validate-cask.yml
+  workflow_dispatch:
+
+concurrency:
+  group: validate-cask-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-hackdesk-cask:
+    name: Validate hackdesk cask
+    runs-on: macos-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_ENV_HINTS: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      LOCAL_TAP: local/hackdesk-pr
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Show Homebrew version
+        run: brew --version
+
+      - name: Tap checked-out repository
+        run: brew tap "$LOCAL_TAP" "$GITHUB_WORKSPACE"
+
+      - name: Audit cask
+        run: brew audit --cask --strict "$LOCAL_TAP/hackdesk"
+
+      - name: Fetch cask payload
+        run: brew fetch --cask "$LOCAL_TAP/hackdesk"
+
+      - name: Install cask from PR
+        run: brew install --cask --appdir="$RUNNER_TEMP/Applications" "$LOCAL_TAP/hackdesk"
+
+      - name: Verify cask is installed
+        run: brew list --cask hackdesk
+
+      - name: Verify installed app
+        run: test -d "$RUNNER_TEMP/Applications/HackDesk.app"
+
+      - name: Cleanup Homebrew state
+        if: always()
+        run: |
+          brew uninstall --cask hackdesk || true
+          brew untap "$LOCAL_TAP" || true


### PR DESCRIPTION
## Summary

- add a PR validation workflow for `Casks/hackdesk.rb`
- validate the checked-out tap by tapping it locally before `brew audit` / `brew fetch`
- install into a temporary app directory and clean up Homebrew state after the check

## Why

This gives `homebrew-hackdesk` a branch-protection-friendly CI check for future manual updates and for the automated PRs opened from the main `hackdesk` release flow.
